### PR TITLE
Fix right sidebar resizing behavior

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -80,21 +80,53 @@ body,
   background: var(--color-text-muted);
 }
 
-[data-panel-group-direction="horizontal"] > [data-resize-handle] {
-  width: 4px;
+[data-panel-group-direction="horizontal"] > [data-separator] {
+  position: relative;
+  width: 12px;
+  background: transparent;
+  z-index: 2;
+}
+[data-panel-group-direction="horizontal"] > [data-separator]::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  border-radius: 9999px;
   background: var(--color-border);
-  transition: background 0.15s;
+  transition: background-color 0.15s, box-shadow 0.15s;
 }
-[data-panel-group-direction="horizontal"] > [data-resize-handle]:hover,
-[data-panel-group-direction="horizontal"] > [data-resize-handle][data-resize-handle-active] {
+[data-panel-group-direction="horizontal"] > [data-separator]:hover::after,
+[data-panel-group-direction="horizontal"] > [data-separator]:focus-visible::after,
+[data-panel-group-direction="horizontal"] > [data-separator][data-separator="hover"]::after,
+[data-panel-group-direction="horizontal"] > [data-separator][data-separator="active"]::after {
   background: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
-[data-panel-group-direction="vertical"] > [data-resize-handle] {
-  height: 4px;
+[data-panel-group-direction="vertical"] > [data-separator] {
+  position: relative;
+  height: 12px;
+  background: transparent;
+  z-index: 2;
+}
+[data-panel-group-direction="vertical"] > [data-separator]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+  border-radius: 9999px;
   background: var(--color-border);
-  transition: background 0.15s;
+  transition: background-color 0.15s, box-shadow 0.15s;
 }
-[data-panel-group-direction="vertical"] > [data-resize-handle]:hover,
-[data-panel-group-direction="vertical"] > [data-resize-handle][data-resize-handle-active] {
+[data-panel-group-direction="vertical"] > [data-separator]:hover::after,
+[data-panel-group-direction="vertical"] > [data-separator]:focus-visible::after,
+[data-panel-group-direction="vertical"] > [data-separator][data-separator="hover"]::after,
+[data-panel-group-direction="vertical"] > [data-separator][data-separator="active"]::after {
   background: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }

--- a/src/ui/layout/AppLayout.tsx
+++ b/src/ui/layout/AppLayout.tsx
@@ -14,7 +14,12 @@ export function AppLayout() {
     <div className="h-screen w-screen flex flex-col overflow-hidden">
       <GlobalBar />
 
-      <Group orientation="horizontal" className="flex-1">
+      <Group
+        orientation="horizontal"
+        className="flex-1"
+        data-panel-group-direction="horizontal"
+        resizeTargetMinimumSize={{ fine: 12, coarse: 28 }}
+      >
         {/* Left sidebar */}
         <Panel defaultSize={20} minSize={14} maxSize={30}>
           <LeftSidebar />
@@ -23,7 +28,11 @@ export function AppLayout() {
 
         {/* Center: 3D + Bottom */}
         <Panel defaultSize={55} minSize={30}>
-          <Group orientation="vertical">
+          <Group
+            orientation="vertical"
+            data-panel-group-direction="vertical"
+            resizeTargetMinimumSize={{ fine: 12, coarse: 28 }}
+          >
             {/* 3D Viewer */}
             <Panel defaultSize={70} minSize={30}>
               <ViewerCanvas />
@@ -39,7 +48,12 @@ export function AppLayout() {
         <Separator />
 
         {/* Right sidebar */}
-        <Panel defaultSize={25} minSize={15} maxSize={35}>
+        <Panel
+          defaultSize="360px"
+          minSize="280px"
+          maxSize="560px"
+          groupResizeBehavior="preserve-pixel-size"
+        >
           <RightSidebar />
         </Panel>
       </Group>


### PR DESCRIPTION
## Summary
- make the panel separators visible and easier to grab with a wider hit area
- increase the right sidebar width range and preserve pixel-based resizing for readability
- align separator styling with the current react-resizable-panels data attributes

## Testing
- npm run build